### PR TITLE
Added exception handling to __call__ of SocketMiddleware

### DIFF
--- a/flask_sockets.py
+++ b/flask_sockets.py
@@ -31,14 +31,13 @@ class SocketMiddleware(object):
 
     def __call__(self, environ, start_response):
         path = environ['PATH_INFO']
-
-        if path in self.ws.url_map:
+        try:
             handler = self.ws.url_map[path]
-            environment = environ['wsgi.websocket']
-
-            handler(environment)
-        else:
+        except KeyError: #Path not in URL map. Alert user of problem or log the error?
             return self.app(environ, start_response)
+        else:
+            environment = environ['wsgi.websocket']
+            handler(environment)
 
 
 class Sockets(object):


### PR DESCRIPTION
In keeping with Python's EAFP philosophy, it might be nice to explicitly handle an exception when path isn't in the URL map. It could also make sense to alert the user of the exception to avoid failing silently when the "if" statement is false. What do you think?