### PR TITLE
SocketMiddleware.__call__: avoid exception when 'wsgi.websocket' isn't i...

### DIFF
--- a/flask_sockets.py
+++ b/flask_sockets.py
@@ -34,8 +34,9 @@ class SocketMiddleware(object):
 
         if path in self.ws.url_map:
             handler = self.ws.url_map[path]
-            environment = environ['wsgi.websocket']
+            environment = environ.get('wsgi.websocket')
 
+        if environment:
             handler(environment)
         else:
             return self.app(environ, start_response)

--- a/flask_sockets.py
+++ b/flask_sockets.py
@@ -32,6 +32,8 @@ class SocketMiddleware(object):
     def __call__(self, environ, start_response):
         path = environ['PATH_INFO']
 
+        environment = None
+
         if path in self.ws.url_map:
             handler = self.ws.url_map[path]
             environment = environ.get('wsgi.websocket')


### PR DESCRIPTION
...n the environment.

Such an exception is easy for a client to induce: they need merely
point a web browser at the relevant endpoint.  And the exception might
take a long time to handle -- if we're running under gunicorn, it will
restart the worker; that takes tens or hundreds of milliseconds.  This
way, the browser will probably get a 404, and the server process can
quickly get back to work.