### PR TITLE
Earlier check for websocket environment.

### DIFF
--- a/flask_sockets.py
+++ b/flask_sockets.py
@@ -31,11 +31,10 @@ class SocketMiddleware(object):
 
     def __call__(self, environ, start_response):
         path = environ['PATH_INFO']
+        environment = environ.get('wsgi.websocket', None)
 
-        if path in self.ws.url_map:
+        if path in self.ws.url_map and environment:
             handler = self.ws.url_map[path]
-            environment = environ['wsgi.websocket']
-
             handler(environment)
             return []
         else:


### PR DESCRIPTION
This change stops the websocket handler from trying to handle routes that it shouldn't, e.g. if the user points their browser at a websocket endpoint.