### PR TITLE
Just added a small patch to make the flask_sockets.worker play nicely with gunicorn's access-logformat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Sockets',
-    version='0.2.1',
+    version='0.2.1.1',
     url='https://github.com/kennethreitz/flask-sockets',
     license='See License',
     author='Kenneth Reitz',


### PR DESCRIPTION
Basically, this small patch makes flask_sockets.worker work with gunicorn's access log configuration (rather than the hard-coded .log_request() and .format_request() in pywsgi.WSGIHandler).

Happy to do some polishing :)
